### PR TITLE
sortVms

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,9 @@
 	onMount(async () => {
 		try {
 			const response = await getVMs();
-			vms = response.data;
+			vms = response.data.sort((a, b) => {
+            	return parseInt(a.owner_id) - parseInt(b.owner_id);
+        	});
 		} catch (err) {
 			error = err.message;
 		} finally {


### PR DESCRIPTION
Actuellement, à chaque rechargement de la page, les VMs sont affichées de manière désordonnée.
Avec cette pull request, les VMs sur la page d'accueil seront triées par utilisateur, de celui ayant le plus petit ID à celui ayant le plus grand.
Cette amélioration est particulièrement utile pour les administrateurs, qui peuvent avoir plusieurs VMs et également visualiser celles des autres utilisateurs.


```js
vms = response.data.sort((a, b) => {
        return parseInt(a.owner_id) - parseInt(b.owner_id);
});
```

ce code permet de trier


